### PR TITLE
34 hotfix improved command structure

### DIFF
--- a/Core/User/commands.c
+++ b/Core/User/commands.c
@@ -4,12 +4,14 @@
 #include <string.h>
 #include"logging.h"
 #include "stdio.h"
+#include "usart.h"
+
 
 #define VERBOSE true
-
 #define RX_DMA_BUF_SIZE 128
 #define CMD_MAX_LEN 64
 
+#define UART_HANDLE huart2
 extern UART_HandleTypeDef UART_HANDLE;
 
 volatile bool rxReady = false;

--- a/Core/User/commands.h
+++ b/Core/User/commands.h
@@ -1,12 +1,16 @@
 #pragma once
 
-typedef enum
-{
-    CMD_NONE = 0,
-    CMD_RUN,
-    CMD_HALT,
-    CMD_COUNT        // always keep last
-} Command_t;
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef enum {
+    CMD_NONE            = 0x00,
+    CMD_RUN             = 0x01,
+    CMD_HALT            = 0x02,
+    CMD_EMAG_ENABLE     = 0xf1,
+    CMD_EMAG_DISABLE    = 0xf2,
+    CMD_EMAG_TOGGLE     = 0xf3
+} t_command;
 
 
 void init_commands(void);

--- a/Core/User/commands.h
+++ b/Core/User/commands.h
@@ -1,9 +1,5 @@
 #pragma once
 
-#include "usart.h"
-
-#define UART_HANDLE huart2
-
 typedef enum
 {
     CMD_NONE = 0,


### PR DESCRIPTION
# Summary

Commands for all subsystems can be added to the following structure in `commands.h`:

```c
typedef enum {
    CMD_NONE            = 0x00,
    CMD_RUN             = 0x01,
    CMD_HALT            = 0x02,
    ...
    CMD_EMAG_ENABLE     = 0xf1,
    CMD_EMAG_DISABLE    = 0xf2,
    CMD_EMAG_TOGGLE     = 0xf3    
} t_command;
```